### PR TITLE
Fix code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/install/landing-page/bootstrap/js/bootstrap.js
+++ b/install/landing-page/bootstrap/js/bootstrap.js
@@ -664,7 +664,7 @@ if (typeof jQuery === "undefined") { throw new Error("Bootstrap requires jQuery"
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()
     var parent  = $this.attr('data-parent')
-    var $parent = parent && $(parent)
+    var $parent = parent && $(document).find($.escapeSelector(parent))
 
     if (!data || !data.transitioning) {
       if ($parent) $parent.find('[data-toggle=collapse][data-parent="' + parent + '"]').not($this).addClass('collapsed')


### PR DESCRIPTION
Fixes [https://github.com/shampuronline/newfies-dialer/security/code-scanning/5](https://github.com/shampuronline/newfies-dialer/security/code-scanning/5)

To fix the problem, we need to ensure that the value of the `data-parent` attribute is properly sanitized before it is used in a jQuery selector. One way to do this is to use a method that treats the value as a CSS selector rather than HTML, thereby preventing any potential XSS attacks.

The best way to fix this issue is to use the `$.escapeSelector` method provided by jQuery to escape any meta-characters in the `data-parent` attribute value. This method ensures that the value is treated as a plain text string and not as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
